### PR TITLE
LCOE breakdown method for annual workflows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,14 @@ repos:
   hooks:
   - id: isort
     name: isort
-    stages: [commit]
+    stages: [pre-commit]
 
 - repo: https://github.com/psf/black
   rev: 23.11.0
   hooks:
   - id: black
     name: black
-    stages: [commit]
+    stages: [pre-commit]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: 'v1.7.0'  # Use the sha / tag you want to point at

--- a/waves/project.py
+++ b/waves/project.py
@@ -2559,3 +2559,27 @@ class Project(FromDictMixin):
         results_df.index = pd.Index([simulation_name])
         results_df.index.name = "Project"
         return results_df
+
+
+    def generate_report_lcoe_breakdown(
+        self,
+    ) -> pd.DataFrame:
+        """Generates a single a dataframe of all the desired LCOE metrics from the project.
+
+        .. note:: This structure is in line with the required structure for plotting routines
+        in the Cost of Wind Energy Review
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        pd.DataFrame
+            A pandas.DataFrame containing all of the required LCOE outputs for plotting 
+            routines in the Cost of Wind Energy Review 
+
+        Raises
+        ------
+        ValueError
+            Raised if ...
+        """

--- a/waves/project.py
+++ b/waves/project.py
@@ -2638,7 +2638,6 @@ class Project(FromDictMixin):
         df["Category"] = pd.Categorical(
             df["Category"], categories=order_of_categories, ordered=True
         )
-        df = df.sort_values(by="Category")
         df = (
             df.sort_values(by=["Category", "Original Order"])
             .drop(columns=["Original Order"])


### PR DESCRIPTION
The purpose of this pull request is to introduce a new method that generates a dataframe structured as follows: 

Component | Category | Value ($/kW) | Fixed charge   rate (FCR) (real) | Value ($/kW-yr) | Net AEP   (MWh/kW/yr) | Value ($/MWh)
-- | -- | -- | -- | -- | -- | --
Turbine | Turbine | 1700.0000 | 0.0648 | 110.16 | 3.34632 | 32.91974467
Array System | Balance of System CapEx | 251.0947 | 0.0648 | 16.27093499 | 3.34632 | 4.862336831
Export System | Balance of System CapEx | 142.8433 | 0.0648 | 9.25624597 | 3.34632 | 2.766097077
Offshore Substation | Balance of System CapEx | 187.4795 | 0.0648 | 12.14867238 | 3.34632 | 3.630457453
Substructure | Balance of System CapEx | 1188.6430 | 0.0648 | 77.02406582 | 3.34632 | 23.0175434
Mooring System | Balance of System CapEx | 519.4231 | 0.0648 | 33.65861661 | 3.34632 | 10.05839747
Array System Installation | Balance of System CapEx | 284.9460 | 0.0648 | 18.46449855 | 3.34632 | 5.517852015
Export System Installation | Balance of System CapEx | 265.5347 | 0.0648 | 17.2066501 | 3.34632 | 5.141961946
Offshore Substation   Installation | Balance of System CapEx | 25.0795 | 0.0648 | 1.625152779 | 3.34632 | 0.485653727
Substructure Installation | Balance of System CapEx | 157.7475 | 0.0648 | 10.22203655 | 3.34632 | 3.054709815
Mooring System Installation | Balance of System CapEx | 120.8337 | 0.0648 | 7.830026741 | 3.34632 | 2.339891804
Project | Balance of System CapEx | 98.2825 | 0.0648 | 6.368705038 | 3.34632 | 1.903196657
Lease Price | Balance of System CapEx | 166.6667 | 0.0648 | 10.8 | 3.34632 | 3.227425949
Construction Insurance | Financial CapEx | 58.9020 | 0.0648 | 3.816848855 | 3.34632 | 1.140610837
Decomissioning | Financial CapEx | 147.3394 | 0.0648 | 9.547592913 | 3.34632 | 2.853161955
Construction Financing | Financial CapEx | 254.9402 | 0.0648 | 16.52012267 | 3.34632 | 4.936803015
Procurement Contingency | Financial CapEx | 245.3968 | 0.0648 | 15.90171331 | 3.34632 | 4.752000199
Install. Contingency | Financial CapEx | 294.6788 | 0.0648 | 19.09518583 | 3.34632 | 5.706323912
Project Completion | Financial CapEx | 58.9020 | 0.0648 | 3.816848855 | 3.34632 | 1.140610837
Labor   (technicians) | OpEx |   |   | 4 | 3.34632 | 1.195342944
Materials | OpEx |   |   | 3 | 3.34632 | 0.896507208
Equipment (vessels) | OpEx |   |   | 49 | 3.34632 | 14.64295106
Management administration | OpEx |   |   | 2 | 3.34632 | 0.597671472
Port fees | OpEx |   |   | 14 | 3.34632 | 4.183700304
Insurance | OpEx |   |   | 15 | 3.34632 | 4.48253604


This dataframe will combine the CapEx and OpEx outputs from ORBIT and WOMBAT, respectively, and will also incorporate key parameters from the configuration file, such as the FCR, along with relevant outputs from WAVES, including the net AEP.



